### PR TITLE
Bug when quotes in comments

### DIFF
--- a/flowercase/flowercase.py
+++ b/flowercase/flowercase.py
@@ -45,6 +45,7 @@ for line in infile:
   line_new = ''
   word = ''
   commentmode = False
+  stringmode = False
 
   for character in line:
     if not character.isalnum() and character<>'_':


### PR DESCRIPTION
There seems to be a bug when quotes are present in comments.  Run flowercase.py on this file to see the bug in two places:

``` Fortran

!
!     Klioner, Sergei A., "A practical relativistic model for micro-
!     arcsecond astrometry in space", Astr. J. 125, 1580-1597 (2003).
!
!  Called:
!     iau_PDP      scalar product of two p-vectors
!

!  Reference epoch (J2000.0), JD
DOUBLE PRECISION DJ00
PARAMETER ( DJ00 = 2451545D0 )
!
!  Matrix elements for orienting the analytical model to DE405/ICRF.
!
!  The corresponding Euler angles are:
!
!                        d  '  "
!    1st rotation    -  23 26 21.4091 about the x-axis  (obliquity)
!    2nd rotation    +         0.0475 about the z-axis  (RA offset)
!
!  These were obtained empirically, by comparisons with DE405 over
!  1900-2100.
!
DOUBLE PRECISION AM12, AM13, AM21, AM22, AM23, AM32, AM33
PARAMETER ( AM12 = +0.000000211284D0, &
            AM13 = -0.000000091603D0, &
            AM21 = -0.000000230286D0, &
            AM22 = +0.917482137087D0, &
            AM23 = -0.397776982902D0, &
            AM32 = +0.397776982902D0, &
            AM33 = +0.917482137087D0 )
```

Note that the "J" in the comment is being improperly lowercased, and then none of the code at the end is being lowercased.

This PR seems to fix the problem. 
